### PR TITLE
Remove JDK requirements part in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ you push changes to the repository for reviewing:
 If you encounter an error when use `./gradlew spotlessApply`, you should fix format errors
 manually, because the Spotless based formatter can't fix all errors.
 
-## JDK Requirement
-
-JDK 17 as BoringdroidSystemUI uses AGP 8.x+.
-
 ## Release
 
 The `BoringdroidSystemUI` is released with apk, and you can use the following commands build apk:


### PR DESCRIPTION
I think Gradle will tell developer which JDK that it needs.